### PR TITLE
ajout de la possibilité de créer plusieurs bots sur une même instance EC2 en créant un repertoire par bot 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ Une fois connecté à votre serveur il suffit de faire 2 commandes:
 
 > git clone https://github.com/CryptoRobotFr/easy_live.git (attention ne pas copier coller toute la commande)
 
-> bash easy_live/install.sh
+renommer le repertoire easy_live si vous souhaitez avoir plusieurs bots 
+> cd <votre repertoire>
+> bash install.sh
 
 Ensuite il suffit de suivre les instructions en rentrant vos clé api FTX, le nom de votre sous compte, et enfin le nom de la stratégie souhaité parmis la liste ci dessous. Une fois que tout est fait si vous n'avez pas de message d'erreur c'est que tout est bon.
+
+vous pouvez avoir les infos de la derniere execution du bot dans le fichier cronlog.log
 
 ## Liste des stratégies disponibles:
 - cross_ema_secure

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,11 @@ read subaccount_name
 sudo apt-get update
 sudo apt install pip -y
 sudo apt install jq -y
-pip install -r easy_live/requirements.txt
+
+//permet d avoir plusieurs bot dans des folders differents
+folder_name = os.path.basename(directory_path)
+
+pip install -r folder_name/requirements.txt
 
 secret_file=secret.json
 if test -f "$secret_file"; then
@@ -33,12 +37,13 @@ fi
 secret_content=`cat secret.json`
 $secret_content | jq '. + { "'"$strategy_name"'_'"$symbol1"'_'"$symbol2"'":{"public_key" : "'"$public_key"'","private_key" : "'"$private_key"'","subaccount_name" : "'"$subaccount_name"'","symbol1" : "'"$symbol1"'","symbol2" : "'"$symbol2"'"} }' secret.json > tmp.$$.json && mv tmp.$$.json secret.json
 
-croncmd="python3 easy_live/"$strategy_name".py "$symbol1" "$symbol2" > cronlog.log"
+croncmd=" cd "$folder_name";python3 /"$strategy_name".py "$symbol1" "$symbol2" > cronlog.log"
 cronjob="0 * * * * $croncmd"
 ( crontab -l | grep -v -F "$croncmd" ; echo "$cronjob" ) | crontab -
 
-echo L erreur comand not found n est pas un probleme
+echo L erreur command not found n est pas un probleme
 
-python3 easy_live/"$strategy_name".py "$symbol1" "$symbol2"
+python3 "$folder_name"/"$strategy_name".py "$symbol1" "$symbol2"
 
 echo Si votre programme vous a afficher un message qui ne ressemble pas a une erreur c est que tout est bien installe vous pouvez maintenant quitter par exemple en faisant par exemple la comande close
+echo vous pouvez verifier que votre bot tourne en tapant \" crontab -l \" , vous aurez une ligne de type $croncmd

--- a/install.sh
+++ b/install.sh
@@ -15,10 +15,10 @@ sudo apt-get update
 sudo apt install pip -y
 sudo apt install jq -y
 
-//permet d avoir plusieurs bot dans des folders differents
-folder_name = os.path.basename(directory_path)
+#permet d avoir plusieurs bot dans des folders differents
+folder_name=${PWD}
 
-pip install -r folder_name/requirements.txt
+pip install -r $folder_name/requirements.txt
 
 secret_file=secret.json
 if test -f "$secret_file"; then
@@ -37,7 +37,7 @@ fi
 secret_content=`cat secret.json`
 $secret_content | jq '. + { "'"$strategy_name"'_'"$symbol1"'_'"$symbol2"'":{"public_key" : "'"$public_key"'","private_key" : "'"$private_key"'","subaccount_name" : "'"$subaccount_name"'","symbol1" : "'"$symbol1"'","symbol2" : "'"$symbol2"'"} }' secret.json > tmp.$$.json && mv tmp.$$.json secret.json
 
-croncmd=" cd "$folder_name";python3 /"$strategy_name".py "$symbol1" "$symbol2" > cronlog.log"
+croncmd=" cd "$folder_name";python3 "$strategy_name".py "$symbol1" "$symbol2" > cronlog.log"
 cronjob="0 * * * * $croncmd"
 ( crontab -l | grep -v -F "$croncmd" ; echo "$cronjob" ) | crontab -
 
@@ -45,5 +45,6 @@ echo L erreur command not found n est pas un probleme
 
 python3 "$folder_name"/"$strategy_name".py "$symbol1" "$symbol2"
 
-echo Si votre programme vous a afficher un message qui ne ressemble pas a une erreur c est que tout est bien installe vous pouvez maintenant quitter par exemple en faisant par exemple la comande close
+echo Si votre programme vous a afficher un message qui ne ressemble pas a une erreur c est que tout est bien installe 
 echo vous pouvez verifier que votre bot tourne en tapant \" crontab -l \" , vous aurez une ligne de type $croncmd
+echo vous pouvez maintenant quitter par exemple en faisant par exemple la commande \"exit\"

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ fi
 secret_content=`cat secret.json`
 $secret_content | jq '. + { "'"$strategy_name"'_'"$symbol1"'_'"$symbol2"'":{"public_key" : "'"$public_key"'","private_key" : "'"$private_key"'","subaccount_name" : "'"$subaccount_name"'","symbol1" : "'"$symbol1"'","symbol2" : "'"$symbol2"'"} }' secret.json > tmp.$$.json && mv tmp.$$.json secret.json
 
-croncmd=" cd "$folder_name";python3 "$strategy_name".py "$symbol1" "$symbol2" > cronlog.log"
+croncmd="cd "$folder_name";python3 "$strategy_name".py "$symbol1" "$symbol2" > cronlog.log"
 cronjob="0 * * * * $croncmd"
 ( crontab -l | grep -v -F "$croncmd" ; echo "$cronjob" ) | crontab -
 


### PR DESCRIPTION
Salut CryptoRobotFr, 
Je me suis permis de modifier un peu le script d'install pour pouvoir avoir plusieurs bots sur une instance EC2. Le petit soucis était  que le chemin du script python était en dur dans le code. 
du coup on peut maintenant renommer le repertoire easy_live en cryptobot_eth_usd par exemple, c'est pris en compte dans l'install et dans la crontab ..  on peut ainsi installer plusieurs bots  

Thavi (student BP)